### PR TITLE
Changing color scheme

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,12 +1,16 @@
 module ApplicationHelper
   def amount_to_color(amount)
     case
-    when round(amount) < 4.0 || round(amount) >= 7.0
-      'red'
+    when round(amount) < 4.0
+      'white'
+    when round(amount) >= 4.0 && round(amount) < 5.0
+      'blue'
     when round(amount) >= 5.0 && round(amount) < 6.0
       'green'
-    else
+    when round(amount) >= 6.0 && round(amount) < 7.0
       'yellow'
+    else
+      'red'
     end
   end
 


### PR DESCRIPTION
I really like the concept of indicating when someone has gone past 6 hours and needs to slow down. The trouble is that it makes the board harder to interpret when glancing at it. Yellow shouldn't represent both an "okay, but work a little more towards green" and "you're past green, better slow down". Same principle holds true for red too.

I propose this tweak:
0.0-3.9 - white or no dot
4.0-4.9 - blue, preferably Detroit Lions blue
5.0-5.9 - green
6.0-6.9 - yellow
7.0+ - red
